### PR TITLE
Add save function when log buffer fills too high

### DIFF
--- a/DaxxnLoggerLibrary/ConsoleLogger.cs
+++ b/DaxxnLoggerLibrary/ConsoleLogger.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Threading.Tasks;
+
 using DaxxnLoggerLibrary.Models;
 
 namespace DaxxnLoggerLibrary
@@ -10,7 +12,17 @@ namespace DaxxnLoggerLibrary
    {
       #region Constructors
       /// <summary>
+      /// Creates a new <see cref="ConsoleLogger"/> at the end of the chain.
+      /// <para>
+      /// See <see href="https://en.wikipedia.org/wiki/Chain-of-responsibility_pattern">Chain of Responibility Pattern.</see>
+      /// </para>
+      /// </summary>
+      public ConsoleLogger() : base() { }
+      /// <summary>
       /// Creates a new <see cref="ConsoleLogger"/>.
+      /// <para>
+      /// See <see href="https://en.wikipedia.org/wiki/Chain-of-responsibility_pattern">Chain of Responibility Pattern.</see>
+      /// </para>
       /// </summary>
       /// <param name="next">Next logger in the chain.</param>
       public ConsoleLogger(ILogger next) : base(next) { }
@@ -21,7 +33,13 @@ namespace DaxxnLoggerLibrary
       protected override void AbstLog(ILog log) => Console.WriteLine(log);
 
       /// <inheritdoc/>
+      protected override async Task AbstLogAsync(ILog log) => await Task.Run(() => AbstLog(log));
+
+      /// <inheritdoc/>
       protected override void AbstSave() => Console.WriteLine("Save Logs");
+
+      /// <inheritdoc/>
+      protected override async Task AbstSaveAsync() => await Task.Run(() => AbstSave());
       #endregion
    }
 }

--- a/DaxxnLoggerLibrary/DaxxnLoggerLibrary.csproj
+++ b/DaxxnLoggerLibrary/DaxxnLoggerLibrary.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net6.0;net462;net47;net48</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
-     <Version>1.2.0</Version>
+     <Version>1.3.0</Version>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageProjectUrl></PackageProjectUrl>
     <RepositoryUrl>https://github.com/Daxxn/DaxxnLoggerLibrary.git</RepositoryUrl>

--- a/DaxxnLoggerLibrary/ILogger.cs
+++ b/DaxxnLoggerLibrary/ILogger.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 
 using DaxxnLoggerLibrary.Models;
 
@@ -15,12 +16,6 @@ namespace DaxxnLoggerLibrary
       List<ILog> Logs { get; }
 
       /// <summary>
-      /// Serialize logs as a binary stream to reduce file size.
-      /// </summary>
-      /// <returns>Stream of serialized bytes</returns>
-      byte[] SerializeLogs();
-
-      /// <summary>
       /// Saves the logs.
       /// <para>
       /// Do nothing if saving is not required.
@@ -33,5 +28,13 @@ namespace DaxxnLoggerLibrary
       /// </summary>
       /// <param name="log"><see cref="ILog"/> to add.</param>
       void Log(ILog log);
+
+      /// <summary>
+      /// Add a <see cref="ILog"/> to the buffer async.
+      /// <para/>
+      /// Will also check the log file size.
+      /// </summary>
+      /// <param name="log"><see cref="ILog"/> to add.</param>
+      Task LogAsync(ILog log);
    }
 }

--- a/DaxxnLoggerLibrary/LoggerBase.cs
+++ b/DaxxnLoggerLibrary/LoggerBase.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 
 using DaxxnLoggerLibrary.Models;
 
@@ -19,14 +20,21 @@ namespace DaxxnLoggerLibrary
       /// Next logger in the chain.
       /// <see langword="null"/> if end of chain.
       /// </summary>
-      protected ILogger Next { get; private set; }
+      protected ILogger Next { get; private set; } = null;
       #endregion
 
       #region Constructors
       /// <summary>
+      /// Constructs a base logger without a logger next in the chain.
+      /// <para>
+      /// See <see href="https://en.wikipedia.org/wiki/Chain-of-responsibility_pattern">Chain of Responibility Pattern.</see>
+      /// </para>
+      /// </summary>
+      public LoggerBase() { }
+      /// <summary>
       /// Construct logger and append next logger in chain.
       /// <para>
-      /// See <see href="https://en.wikipedia.org/wiki/Chain-of-responsibility_pattern">Chain of Responibility Pattern</see>
+      /// See <see href="https://en.wikipedia.org/wiki/Chain-of-responsibility_pattern">Chain of Responibility Pattern.</see>
       /// </para>
       /// </summary>
       /// <param name="next">Next logger in chain.</param>
@@ -34,26 +42,6 @@ namespace DaxxnLoggerLibrary
       #endregion
 
       #region Methods
-      /// <summary>
-      /// Serialize logs as a binary stream to reduce file size.
-      /// </summary>
-      /// <returns>Stream of serialized bytes</returns>
-      public byte[] SerializeLogs()
-      {
-         List<byte> output = new List<byte>()
-         {
-            29,
-         };
-         foreach (var log in Logs)
-         {
-            output.AddRange(log.Serialize());
-            output.Add((byte)'\n');
-         }
-
-         output.Add(29);
-         return output.ToArray();
-      }
-
       /// <summary>
       /// Saves the logs.
       /// <para>
@@ -77,15 +65,46 @@ namespace DaxxnLoggerLibrary
       }
 
       /// <summary>
+      /// Add a <see cref="ILog"/> to the buffer async.
+      /// </summary>
+      /// <param name="log"><see cref="ILog"/> to add.</param>
+      public async Task LogAsync(ILog log)
+      {
+         await AbstLogAsync(log);
+         Next?.LogAsync(log);
+      }
+
+      /// <summary>
+      /// Add a <see cref="ILog"/> to the buffer.
+      /// </summary>
+      /// <param name="type">Log type</param>
+      /// <param name="message">Log message</param>
+      public void Log(LogType type, string message)
+      {
+         Log(new Log(type, message));
+      }
+
+      /// <summary>
       /// When overriden in a derived class, defines what the logger will do when an <see cref="ILog"/> is generated.
       /// </summary>
       /// <param name="log"><see cref="ILog"/> to pass down the chain.</param>
       protected abstract void AbstLog(ILog log);
 
       /// <summary>
+      /// When overriden in a derived class, defines what the logger will do when an <see cref="ILog"/> is generated.
+      /// </summary>
+      /// <param name="log"><see cref="ILog"/> to pass down the chain.</param>
+      protected abstract Task AbstLogAsync(ILog log);
+
+      /// <summary>
       /// When overriden in a derived class, defines what the logger will do when the log buffer is saved.
       /// </summary>
       protected abstract void AbstSave();
+
+      /// <summary>
+      /// When overriden in a derived class, defines what the logger will do when the log buffer is saved asyncronously.
+      /// </summary>
+      protected abstract Task AbstSaveAsync();
       #endregion
    }
 }

--- a/DaxxnLoggerLibrary/Models/Log.cs
+++ b/DaxxnLoggerLibrary/Models/Log.cs
@@ -14,6 +14,14 @@ namespace DaxxnLoggerLibrary.Models
       Warning = 1,
       /// <inheritdoc/>
       Information = 2,
+      /// <summary>
+      /// Something not specified. Not recommended to be used that often.
+      /// </summary>
+      Other = 3,
+      /// <inheritdoc/>
+      Action = 4,
+      /// <inheritdoc/>
+      FileManagement = 5,
    }
 
    /// <summary>

--- a/LoggerTestClient/LoggerTestClient.csproj
+++ b/LoggerTestClient/LoggerTestClient.csproj
@@ -7,4 +7,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\DaxxnLoggerLibrary\DaxxnLoggerLibrary.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/LoggerTestClient/Program.cs
+++ b/LoggerTestClient/Program.cs
@@ -1,10 +1,25 @@
-﻿namespace LoggerTestClient
+﻿using DaxxnLoggerLibrary;
+using DaxxnLoggerLibrary.Models;
+
+namespace LoggerTestClient
 {
-    internal class Program
-    {
-        static void Main(string[] args)
-        {
-            Console.WriteLine("Testing Client for DaxxnLoggerLibrary");
-        }
-    }
+   internal class Program
+   {
+      static void Main(string[] args)
+      {
+         Console.WriteLine("Testing Client for DaxxnLoggerLibrary");
+
+         string logPath = @"F:\Code\C#\CSharpLibraries\DaxxnLoggerLibrary\LoggerTestClient\TestLog.log";
+
+         ConsoleLogger console = new();
+         FileLogger logger = new(console, logPath);
+
+         for (int i = 0; i < 200; i++)
+         {
+            logger.Log(LogType.Information, $"Log {i}");
+         }
+
+         logger.Save();
+      }
+   }
 }


### PR DESCRIPTION
Prevents logs from stacking up to infinity. Now when the log buffer fills up to a point, it's appended to the end of the file and cleared. Before saving to the file, the length of the file is checked. If the length will be too long, the old logs are removed from the file.